### PR TITLE
Prevent globbing and word splitting in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,9 @@ cd ..
 rm -rf releases
 mkdir releases
 
-GOOS=darwin GOARCH=amd64 packr build && zip ./releases/vertcoin-extras-$1-mac-x64.zip vertcoin-extras && rm vertcoin-extras \
-  && GOOS=linux GOARCH=amd64 packr build && zip ./releases/vertcoin-extras-$1-linux-x64.zip vertcoin-extras && rm vertcoin-extras \
-  && GOOS=linux GOARCH=386 packr build && zip ./releases/vertcoin-extras-$1-linux-x86.zip vertcoin-extras && rm vertcoin-extras \
-  && GOOS=windows GOARCH=amd64 packr build && zip ./releases/vertcoin-extras-$1-windows-x64.zip vertcoin-extras.exe && rm vertcoin-extras.exe \
-  && GOOS=windows GOARCH=386 packr build && zip ./releases/vertcoin-extras-$1-windows-x86.zip vertcoin-extras.exe && rm vertcoin-extras.exe \
+GOOS=darwin GOARCH=amd64 packr build && zip ./releases/vertcoin-extras-"$1"-mac-x64.zip vertcoin-extras && rm vertcoin-extras \
+  && GOOS=linux GOARCH=amd64 packr build && zip ./releases/vertcoin-extras-"$1"-linux-x64.zip vertcoin-extras && rm vertcoin-extras \
+  && GOOS=linux GOARCH=386 packr build && zip ./releases/vertcoin-extras-"$1"-linux-x86.zip vertcoin-extras && rm vertcoin-extras \
+  && GOOS=windows GOARCH=amd64 packr build && zip ./releases/vertcoin-extras-"$1"-windows-x64.zip vertcoin-extras.exe && rm vertcoin-extras.exe \
+  && GOOS=windows GOARCH=386 packr build && zip ./releases/vertcoin-extras-"$1"-windows-x86.zip vertcoin-extras.exe && rm vertcoin-extras.exe \
   && packr clean


### PR DESCRIPTION
📞 ping repo maintainer: @gertjaap 

----

The `build.sh` file should have double quote to prevent globbing and word splitting. *(Source: [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086))*

Quoting variables prevents word splitting and glob expansion, and prevents the script from breaking when input contains spaces, line feeds, glob characters and such.

--[**Suriyaa Sundararuban**](https://suriyaa.tk/) <a href="https://github.com/SuriyaaKudoIsc"><img src="https://assets-cdn.github.com/images/icons/emoji/octocat.png" alt="GitHub Developer" width="18" height="18" /></a> <a href="https://vertcoin.org/team/"><img src="https://cdn.discordapp.com/emojis/430323443918176256.png" alt="Future Official Vertcoin Developer?" width="20" height="20" /></a> (***Donate some VTC:*** `vtc1qxvzg3syau59vrdmr498pdakz0y8w6vu8ynkwll`)